### PR TITLE
Make getSimpleCovering public.

### DIFF
--- a/Sources/Classes/S2SimpleRegionCoverer.swift
+++ b/Sources/Classes/S2SimpleRegionCoverer.swift
@@ -18,7 +18,7 @@ public class S2SimpleRegionCoverer {
    region, returns a set of cells at the given level that cover the region.
    The output cells are returned in arbitrary order.
    */
-  static func getSimpleCovering(region: S2Region, level: Int) -> [S2CellId] {
+  public static func getSimpleCovering(region: S2Region, level: Int) -> [S2CellId] {
     let startingCell = S2CellId(latlng: region.rectBound.center).parent(level: level)
     var result: [S2CellId] = []
     var all: Set<S2CellId> = [startingCell]

--- a/Tests/S2SimpleRegionCovererTests.swift
+++ b/Tests/S2SimpleRegionCovererTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 jacob_rice. MIT License.
 //
 
-@testable import S2GeometrySwift
+import S2GeometrySwift
 import XCTest
 
 class S2SimpleRegionCovererTests: XCTestCase {


### PR DESCRIPTION
Make getSimpleCovering public and remove @testable from import S2GeometrySwift in S2SimpleRegionCovererTests.swift.